### PR TITLE
Fixed redis timeout arg

### DIFF
--- a/sanic_redis/core.py
+++ b/sanic_redis/core.py
@@ -23,7 +23,7 @@ class SanicRedis:
             else:
                 config = _app.config.get('REDIS')
             for key in ['address', 'db', 'password', 'ssl', 'encoding', 'minsize',
-                        'maxsize', 'create_connection_timeout']:
+                        'maxsize', 'timeout']:
                 if key in config:
                     _c.update({key: config.get(key)})
             _redis = await create_redis_pool(**_c)


### PR DESCRIPTION
create_connection_timeout not exists as kwarg in create_redis_pool
https://github.com/aio-libs/aioredis/blob/v1.2.0/aioredis/commands/__init__.py#L185