### PR TITLE
change close to aclose

### DIFF
--- a/sanic_redis/core.py
+++ b/sanic_redis/core.py
@@ -71,4 +71,4 @@ class SanicRedis:
         @app.listener('after_server_stop')
         async def close_redis(_app, _loop):
             logger.info("[sanic-redis] closing")
-            await self.conn.close()
+            await self.conn.aclose()


### PR DESCRIPTION
DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.0